### PR TITLE
MovableObject의 코들를 변경한다

### DIFF
--- a/Assets/MovableText/Scripts/MovableObject.cs
+++ b/Assets/MovableText/Scripts/MovableObject.cs
@@ -10,27 +10,28 @@ public enum MovableStyle
 
 public class MovableObject : MonoBehaviour
 {
-    public  uint WaitFrame;
+    public uint WaitFrame;
+    [HideInInspector]
+    public uint WaitingFrame;
+
     public float Rotation;
     public float Vibration;
-    public MovableStyle STYLE;
+    public MovableStyle Style;
     public Vector2 PivotPoint;
 
-    private IEnumerator mEUpdate;
-
     public MovableObject(uint waitFrame, float rotation, float vibration, MovableStyle style) {
-        WaitFrame = waitFrame; Vibration = vibration; Rotation = rotation; STYLE = style;
+        WaitFrame = waitFrame; Vibration = vibration; Rotation = rotation; Style = style;
     }
 
     public void Setting(uint waitFrame, float vibration, float rotation, MovableStyle style) {
-        WaitFrame = waitFrame; Vibration = vibration; Rotation = rotation; STYLE = style;
+        WaitFrame = waitFrame; Vibration = vibration; Rotation = rotation; Style = style;
     }
 
     public void Setting(MovCharInfo movCInfo)
     {
         WaitFrame = movCInfo.waitFrame;
 
-        STYLE = movCInfo.movableStyle;
+        Style = movCInfo.movableStyle;
 
         Rotation  = movCInfo.rotation;
         Vibration = movCInfo.vibration;
@@ -45,26 +46,11 @@ public class MovableObject : MonoBehaviour
         }
     }
 
-    private void OnEnable()
+    public void UpdateMe()
     {
-        StartCoroutine(mEUpdate = EUpdate());
-
-        PivotPoint = transform.localPosition;
-    }
-    private void OnDisable()
-    {
-        if (mEUpdate != null) {
-            StopCoroutine(mEUpdate);
-        }
-        mEUpdate = null;
-    }
-    private IEnumerator EUpdate()
-    {
-        while (gameObject.activeSelf)
+        if (++WaitingFrame >= WaitFrame)
         {
-            for (uint i = 0; i < WaitFrame; i++) { yield return null; }
-
-            switch (STYLE)
+            switch (Style)
             {
                 case MovableStyle.Rotation:
                     transform.localRotation = Quaternion.Euler(Vector3.forward * Rotation * Random.Range(-1f, 1f));
@@ -81,7 +67,12 @@ public class MovableObject : MonoBehaviour
                 default:
                     break;
             }
-            
+            WaitingFrame = 0;
         }
+    }
+
+    private void OnEnable()
+    {
+        PivotPoint = transform.localPosition;
     }
 }

--- a/Assets/MovableText/Scripts/MovableObject.cs
+++ b/Assets/MovableText/Scripts/MovableObject.cs
@@ -10,36 +10,30 @@ public enum MovableStyle
 
 public class MovableObject : MonoBehaviour
 {
-    public  uint WaitFrame => mWaitFrame;
-    public float Rotation  => mRotation;
-    public float Vibration => mVibration;
-    public MovableStyle STYLE => mSTYLE;
-
-    [SerializeField] private  uint mWaitFrame;
-    [SerializeField] private float mRotation;
-    [SerializeField] private float mVibration;
-    [SerializeField] private MovableStyle mSTYLE;
-
+    public  uint WaitFrame;
+    public float Rotation;
+    public float Vibration;
+    public MovableStyle STYLE;
     public Vector2 PivotPoint;
 
     private IEnumerator mEUpdate;
 
     public MovableObject(uint waitFrame, float rotation, float vibration, MovableStyle style) {
-        mWaitFrame = waitFrame; mVibration = vibration; mRotation = rotation; mSTYLE = style;
+        WaitFrame = waitFrame; Vibration = vibration; Rotation = rotation; STYLE = style;
     }
 
     public void Setting(uint waitFrame, float vibration, float rotation, MovableStyle style) {
-        mWaitFrame = waitFrame; mVibration = vibration; mRotation = rotation; mSTYLE = style;
+        WaitFrame = waitFrame; Vibration = vibration; Rotation = rotation; STYLE = style;
     }
 
     public void Setting(MovCharInfo movCInfo)
     {
-        mWaitFrame = movCInfo.waitFrame;
+        WaitFrame = movCInfo.waitFrame;
 
-        mSTYLE = movCInfo.movableStyle;
+        STYLE = movCInfo.movableStyle;
 
-        mRotation  = movCInfo.rotation;
-        mVibration = movCInfo.vibration;
+        Rotation  = movCInfo.rotation;
+        Vibration = movCInfo.vibration;
 
         if (gameObject.TryGetComponent(out Text text))
         {
@@ -68,21 +62,21 @@ public class MovableObject : MonoBehaviour
     {
         while (gameObject.activeSelf)
         {
-            for (uint i = 0; i < mWaitFrame; i++) { yield return null; }
+            for (uint i = 0; i < WaitFrame; i++) { yield return null; }
 
-            switch (mSTYLE)
+            switch (STYLE)
             {
                 case MovableStyle.Rotation:
-                    transform.localRotation = Quaternion.Euler(Vector3.forward * mRotation * Random.Range(-1f, 1f));
+                    transform.localRotation = Quaternion.Euler(Vector3.forward * Rotation * Random.Range(-1f, 1f));
                     break;
 
                 case MovableStyle.Vibration:
-                    transform.localPosition = PivotPoint + Random.insideUnitCircle * mVibration;
+                    transform.localPosition = PivotPoint + Random.insideUnitCircle * Vibration;
                     break;
 
                 case MovableStyle.RotationAndVibration:
-                    transform.localPosition = PivotPoint + Random.insideUnitCircle * mVibration;
-                    transform.localRotation = Quaternion.Euler(Vector3.forward * mRotation * Random.Range(-1f, 1f));
+                    transform.localPosition = PivotPoint + Random.insideUnitCircle * Vibration;
+                    transform.localRotation = Quaternion.Euler(Vector3.forward * Rotation * Random.Range(-1f, 1f));
                     break;
                 default:
                     break;

--- a/Assets/MovableText/Scripts/MovableText.cs
+++ b/Assets/MovableText/Scripts/MovableText.cs
@@ -35,7 +35,7 @@ public struct MovCharInfo
         vibration = movableObject.Vibration;
         waitFrame = movableObject.WaitFrame;
 
-        movableStyle = movableObject.STYLE;
+        movableStyle = movableObject.Style;
     }
 }
 
@@ -118,6 +118,14 @@ public class MovableText : MonoBehaviour
         }
         mEOutputOnebyOne = null;
 
+    }
+
+    private void Update()
+    {
+        for (int i = 0; i < _MovObjectArray.Length; ++i)
+        {
+            _MovObjectArray[i].UpdateMe();
+        }
     }
 
     private void CastFading()


### PR DESCRIPTION
- **MovableObject가 업데이트되는 방식을 변경** 
MovableObejct의 업데이트는 UpdateMe함수를 외부에서 호출하는 것으로 이루어지도록 변경한다.
기존의 방식은 각 MovableObject마다 고유의 코루틴을 통해 업데이트하는 방식이었다.

- **MovableObject의 멤버변수에 직접적으로 접근할 수 있도록 변경**
굳이 private로 닫아두어 사용자의 활용도를 제한할 필요가 없기 때문에 읽기만 가능했던 기존의 public 멤버변수를 
쓰기도 가능한 형태로 변경하여 priavate멤버변수를 대체한다.