### PR TITLE
엉뚱하게 사용된 어트리뷰트를 수정한다

### DIFF
--- a/Assets/MovableText/Scripts/MovableComponent/Gradient.cs
+++ b/Assets/MovableText/Scripts/MovableComponent/Gradient.cs
@@ -9,10 +9,11 @@ public class Gradient : MonoBehaviour
     
     [Header("Gradient Property")]
     public float ProgressingTime;
-    public AnimationCurve GradientCurve;
 
-    [SerializeField, Tooltip("value range : 0 ~ 1")] 
-    private Color GradientColor = Color.white;
+    [SerializeField, Tooltip("value range : 0 ~ 1")]
+    private AnimationCurve GradientCurve;
+
+    public Color GradientColor = Color.white;
     public AnimatorUpdateMode UpdateMode;
 
     [Header("User Property")]


### PR DESCRIPTION
GradientColor에 잘못 적용된 접근 수준과, 어트리뷰트를 원래의 의도였던 GradientCurve변수로 옮긴다.